### PR TITLE
Ecp/two moment (#342)

### DIFF
--- a/Exec/thornado_tests/StreamingSineWave/Prob_3d.f90
+++ b/Exec/thornado_tests/StreamingSineWave/Prob_3d.f90
@@ -122,7 +122,7 @@ subroutine ca_initdata(level,time,lo,hi,nscal, &
            state(i,j,k,UFS  ) = state(i,j,k,URHO)
 
            ! This is Ne
-           state(i,j,k,UFX  ) = 0.d0
+           state(i,j,k,UFX  ) = 1.d0
            
         enddo
      enddo
@@ -227,10 +227,11 @@ subroutine ca_init_thornado_data(level,time,lo,hi,nrad_comp,rad_state, &
               znode = zcen + ( float(iznode)-1.5e0_rt )*delta(3)/sqrt(3.0e0_rt)
 
               ! J moment, im = 1
-              if (im .eq. 1) rad_state(i,j,k,ii) = 1.0e0_rt + sin(2.0e0_rt*M_PI*xnode)
+              if (im .eq. 1) rad_state(i,j,k,ii) = 1.0e0_rt + 0.9999e0_rt*sin(2.0e0_rt*M_PI*xnode)
 
               ! H_x moment, im = 2
-              if (im .eq. 2) rad_state(i,j,k,ii) = 1.0e0_rt + sin(2.0e0_rt*M_PI*xnode)
+              if (im .eq. 2) rad_state(i,j,k,ii) = 3.0e10_rt*0.9999e0_rt &
+                              *(1.0e0_rt + 0.9999e0_rt*sin(2.0e0_rt*M_PI*xnode))
 
               ! H_y moment, im = 3
               if (im .eq. 3) rad_state(i,j,k,ii) = 0.0e0_rt

--- a/Source/two_moment/derive_two_moment_nd.F90
+++ b/Source/two_moment/derive_two_moment_nd.F90
@@ -1,7 +1,6 @@
 module derive_thornado_module
 
   use amrex_fort_module, only : rt => amrex_real
-  use UnitsModule, only : Gram, Centimeter, Second
   use RadiationFieldsModule, only : nSpecies
   use ProgramHeaderModule, only : nE, nDOF
 
@@ -48,8 +47,7 @@ contains
                    (im-1)*(nE*nDOF) + &
                    (ie-1)*nDOF + (id-1)
               icount = icount + 1  ! for averaging
-              ! Thornado uses units where c = G = k = 1, Meter = 1, so we need to add units back in
-              J_avg(i,j,k,:) = J_avg(i,j,k,:) + U_R(i,j,k,ii) / ( Gram / Centimeter / Second**2 )
+              J_avg(i,j,k,:) = J_avg(i,j,k,:) + U_R(i,j,k,ii)
             end do
             end do
             end do
@@ -96,8 +94,7 @@ contains
                    (im-1)*(nE*nDOF) + &
                    (ie-1)*nDOF + (id-1)
               icount = icount + 1  ! for averaging
-              ! Thornado uses units where c = G = k = 1, Meter = 1, so we need to add units back in
-              Hx_avg(i,j,k,:) = Hx_avg(i,j,k,:) + U_R(i,j,k,ii) / ( Gram / Second**3 )
+              Hx_avg(i,j,k,:) = Hx_avg(i,j,k,:) + U_R(i,j,k,ii)
             end do
             end do
             end do
@@ -144,8 +141,7 @@ contains
                    (im-1)*(nE*nDOF) + &
                    (ie-1)*nDOF + (id-1)
               icount = icount + 1  ! for averaging
-              ! Thornado uses units where c = G = k = 1, Meter = 1, so we need to add units back in
-              Hy_avg(i,j,k,:) = Hy_avg(i,j,k,:) + U_R(i,j,k,ii) / ( Gram / Second**3 )
+              Hy_avg(i,j,k,:) = Hy_avg(i,j,k,:) + U_R(i,j,k,ii)
             end do
             end do
             end do
@@ -192,8 +188,7 @@ contains
                    (im-1)*(nE*nDOF) + &
                    (ie-1)*nDOF + (id-1)
               icount = icount + 1  ! for averaging
-              ! Thornado uses units where c = G = k = 1, Meter = 1, so we need to add units back in
-              Hz_avg(i,j,k,:) = Hz_avg(i,j,k,:) + U_R(i,j,k,ii) / ( Gram / Second**3 )
+              Hz_avg(i,j,k,:) = Hz_avg(i,j,k,:) + U_R(i,j,k,ii)
             end do
             end do
             end do


### PR DESCRIPTION
* Add files via upload

* Add files via upload

* Add files via upload

* Add files via upload

* Amended to M_PI

* Add files via upload

* Add files via upload

* Add files via upload

* Slight change to initial conditions for streaming sine wave

Altered so that J > 0 and H_x != J

* Updated radiation unit conversion

Removed unit conversion from derive_two_moment_nd, now doing it inside two_moment_nd where it belongs

* Fix radiation state indices going from Fortran to C

* Add files via upload

* Made Hx units right in Prob_3D

* Amend uCR and uCF indices to work with MPI